### PR TITLE
Add pybind11 module to CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+plugin_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,19 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6.2 FATAL_ERROR)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_MODULE_PATH})
 
+include(FetchContent)
+FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11
+    GIT_TAG        v2.2.3
+)
+
+FetchContent_GetProperties(pybind11)
+if(NOT pybind11_POPULATED)
+    FetchContent_Populate(pybind11)
+    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+endif()
+
 include(FindHOOMD.cmake)
 
 # plugins must be built as shared libraries


### PR DESCRIPTION
Add pybind11 module to CMakeLists.txt

Without the pybind11 module, I can't install the PSE plugin.